### PR TITLE
Add stream flag to requests.get avoid Memory Error

### DIFF
--- a/do_http_get.py
+++ b/do_http_get.py
@@ -6,6 +6,6 @@ def do_get(url, access_token):
                       'Accept': 'application/json',
                       'Authorization': 'Bearer {0}'.format(access_token)}
 
-    response = requests.get(url, params=None, headers=bearer_headers)
+    response = requests.get(url, params=None, headers=bearer_headers, stream=True)
 
     return response


### PR DESCRIPTION
If not add stream flag, large file will be total load into memory, which cause MemoryError on small RAM server.

Here is output run script on my 1GB RAM cloud server.

2019-02-15 17:31:22.045818: The number of zone files to be downloaded is 56
2019-02-15 17:31:22.046053: Downloading zone file from https://czds-api.icann.org/czds/downloads/net.zone
Traceback (most recent call last):
  File "download.py", line 151, in <module>
    download_zone_files(zone_links, working_directory)
  File "download.py", line 147, in download_zone_files
    download_one_zone(link, output_directory)
  File "download.py", line 105, in download_one_zone
    download_zone_response = do_get(url, access_token)
  File "/home/coder4/domain_zone/script/czds-api-client-python/do_http_get.py", line 9, in do_get
    response = requests.get(url, params=None, headers=bearer_headers)
  File "/usr/lib/python3/dist-packages/requests/api.py", line 72, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/lib/python3/dist-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 520, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 670, in send
    r.content
  File "/usr/lib/python3/dist-packages/requests/models.py", line 823, in content
    self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
MemoryError

After Add the flag, every download is OK.