### PR TITLE
Support loading config via env var

### DIFF
--- a/download.py
+++ b/download.py
@@ -12,9 +12,13 @@ from do_http_get import do_get
 ##############################################################################################################
 
 try:
-    config_file = open("config.json", "r")
-    config = json.load(config_file)
-    config_file.close()
+    if 'CZDS_CONFIG' in os.environ:
+        config_data = os.environ['CZDS_CONFIG']
+        config = json.loads(config_data)
+    else:
+        config_file = open("config.json", "r")
+        config = json.load(config_file)
+        config_file.close()
 except:
     sys.stderr.write("Error loading config.json file.\n")
     exit(1)


### PR DESCRIPTION
In addition to loading the config via a `config.json` file, this change allows it to be loaded via an environment variable called `CZDS_CONFIG`. This makes it straightforward to deploy to services like Heroku, which tend to use env vars for config. See https://12factor.net/ for details.