### PR TITLE
Changed to allow only certain TLD zone files to be downloaded, instead of all

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CZDS API Client in Python
 ===========
 
-This repository provides a Python example of how to download zone files via CZDS (Centralized Zone Data Service) REST API. 
+This repository provides a Python example of how to download zone files via CZDS (Centralized Zone Data Service) REST API.
 A detail API Specs can be found [here.](https://github.com/icann/czds-api-client-java/tree/master/docs)
 
 There is also an example provided in Java. It can be found in [this repo.](https://github.com/icann/czds-api-client-java)
@@ -9,7 +9,7 @@ There is also an example provided in Java. It can be found in [this repo.](https
 Installation
 ------------
 
-This script requires Python 3. It has been tested with Python 3.7.1. 
+This script requires Python 3. It has been tested with Python 3.7.1.
 
 It requires the `requests` extension library. Please checkout here to see how to install it - https://github.com/requests/requests
 
@@ -18,9 +18,9 @@ Run
 
 1. Make a copy of the `config.sample.json` file and name it `config.json`
 2. Edit `config.json` and fill in your information.
-2. Run `python download.py`
+2. Run `python download.py <zones to download>`, for example to download the `.com` and `.net` zones the command to run is: `python download.py com net`.
 
-All the zone files will be saved in `working-directory`/zonefiles, `working-directory` is specified in `config.json`, 
+All the zone files will be saved in `working-directory`/zonefiles, `working-directory` is specified in `config.json`,
 or default to current directory if not specified in `config.json`
 
 Documentation

--- a/download.py
+++ b/download.py
@@ -91,7 +91,27 @@ zone_links = get_zone_links(czds_base_url)
 if not zone_links:
     exit(1)
 
+# We may not want to download all the zone files, for a poor connection this will take a long time.
+# So, enable the user to specify which files to download at the command line. They just need to add
+# the TLD of all those that they wish to download, i.e. `python3 download.py net com org` to download
+# the .net, .com, and .org zone files. The zone files downloaded will be a subset of those available
+# and those specified.
 
+# Zones to download are those passed by name
+zones_to_download = sys.argv[1:]
+
+if any([zone == "*" for zone in zones_to_download]):
+    # If any are a *, then just download all
+    pass
+else:
+    # Append .zone to each to make it easier to search
+    zones_to_download = [f"{zone.lower()}.zone" for zone in zones_to_download]
+    zone_links = [zone for zone in zone_links if any([zone.endswith(z) for z in zones_to_download])]
+    if len(zone_links) != len(zones_to_download):
+        # We get here if either we don't have permission to download zones we wanted, or they don't exist
+        not_found = [zone for zone in zones_to_download if not any([z.endswith(zone) for z in zone_links])]
+        print(zone_links, zones_to_download)
+        print("The following zones could not be downloaded because they either do not exist or you do not have permission:\n\t{0}".format('\n\t'.join(not_found)))
 
 ##############################################################################################################
 # Fourth Step: download zone files


### PR DESCRIPTION
Changed the code to enable the user to download only a subset of zone files available to them. Despite the rest of the configuration being performed through the `config.json` file, this pull requests enables the zones to download as command line arguments, this is different, but for my purpose easier. I will need to download various zone files at different times and it is much easier from this perspective to be able to specify the zones to be downloaded as a command line argument as this is much easier than having to change the config file.