### PR TITLE
Use context manager when opening config.json

### DIFF
--- a/download.py
+++ b/download.py
@@ -16,9 +16,8 @@ try:
         config_data = os.environ['CZDS_CONFIG']
         config = json.loads(config_data)
     else:
-        config_file = open("config.json", "r")
-        config = json.load(config_file)
-        config_file.close()
+        with open("config.json", "r") as config_file:
+            config = json.load(config_file)
 except:
     sys.stderr.write("Error loading config.json file.\n")
     exit(1)


### PR DESCRIPTION
Pythonic refactoring: Use context manager when opening config.json