### PR TITLE
tell the user why we couldn't parse the config

### DIFF
--- a/download.py
+++ b/download.py
@@ -19,8 +19,8 @@ try:
         config_file = open("config.json", "r")
         config = json.load(config_file)
         config_file.close()
-except:
-    sys.stderr.write("Error loading config.json file.\n")
+except Exception as e:
+    sys.stderr.write("Error loading config.json file: %s\n" % str(e))
     exit(1)
 
 # The config.json file must contain the following data:


### PR DESCRIPTION
This is useful when e.g., the user edits the config.json.example file instead of copying to config.json and then doesn't understand why the program can't parse the json: with this change, the program will helpfully tell the use that it couldn't find the file "config.json".